### PR TITLE
AMRFM-2439 add pid

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tonynajjar

--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
@@ -76,7 +76,7 @@ private:
   std::unique_ptr<GazeboSystemPrivate> dataPtr;
   boost::shared_ptr<gazebo::physics::JointController> joint_controller_;
   gazebo::physics::JointPtr steering_joint_;
-  gazebo::physics::JointPtr wheel_front_joint_;
+  gazebo::physics::JointPtr traction_joint_;
 };
 
 }  // namespace gazebo_ros2_control

--- a/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
+++ b/gazebo_ros2_control/include/gazebo_ros2_control/gazebo_system.hpp
@@ -23,6 +23,7 @@
 #include "angles/angles.h"
 
 #include "gazebo_ros2_control/gazebo_system_interface.hpp"
+#include "gazebo/physics/JointController.hh"
 
 #include "std_msgs/msg/bool.hpp"
 
@@ -71,12 +72,11 @@ private:
     const hardware_interface::HardwareInfo & hardware_info,
     gazebo::physics::ModelPtr parent_model);
 
-  void registerSensors(
-    const hardware_interface::HardwareInfo & hardware_info,
-    gazebo::physics::ModelPtr parent_model);
-
   /// \brief Private data class
   std::unique_ptr<GazeboSystemPrivate> dataPtr;
+  boost::shared_ptr<gazebo::physics::JointController> joint_controller_;
+  gazebo::physics::JointPtr steering_joint_;
+  gazebo::physics::JointPtr wheel_front_joint_;
 };
 
 }  // namespace gazebo_ros2_control

--- a/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
+++ b/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp
@@ -288,7 +288,6 @@ void GazeboRosControlPlugin::Load(gazebo::physics::ModelPtr parent, sdf::Element
     std::string robot_hw_sim_type_str_ = control_hardware[i].hardware_class_type;
     auto gazeboSystem = std::unique_ptr<gazebo_ros2_control::GazeboSystemInterface>(
       impl_->robot_hw_sim_loader_->createUnmanagedInstance(robot_hw_sim_type_str_));
-
     rclcpp::Node::SharedPtr node_ros2 = std::dynamic_pointer_cast<rclcpp::Node>(impl_->model_nh_);
     if (!gazeboSystem->initSim(
         node_ros2,

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -110,8 +110,6 @@ bool GazeboSystem::initSim(
   double traction_I = std::stod(hardware_info.joints[2].parameters.at("I"));
   double traction_D = std::stod(hardware_info.joints[2].parameters.at("D"));
 
-        RCLCPP_INFO(this->nh_->get_logger(), "steering_P: %f", steering_P);
-
   joint_controller_->SetVelocityPID(steering_joint_->GetScopedName(), gazebo::common::PID(steering_P, steering_I, steering_D));
   joint_controller_->SetPositionPID(traction_joint_->GetScopedName(), gazebo::common::PID(traction_P, traction_I, traction_D));
 

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -19,9 +19,7 @@
 #include <utility>
 
 #include "gazebo_ros2_control/gazebo_system.hpp"
-#include "gazebo/sensors/ImuSensor.hh"
-#include "gazebo/sensors/ForceTorqueSensor.hh"
-#include "gazebo/sensors/SensorManager.hh"
+#include "gazebo/common/common.hh"
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
@@ -34,9 +32,6 @@ public:
 
   /// \brief Degrees od freedom.
   size_t n_dof_;
-
-  /// \brief Number of sensors.
-  size_t n_sensors_;
 
   /// \brief Gazebo Model Ptr.
   gazebo::physics::ModelPtr parent_model_;
@@ -59,29 +54,11 @@ public:
   /// \brief vector with the current joint velocity
   std::vector<double> joint_velocity_;
 
-  /// \brief vector with the current joint effort
-  std::vector<double> joint_effort_;
-
   /// \brief vector with the current cmd joint position
   std::vector<double> joint_position_cmd_;
 
   /// \brief vector with the current cmd joint velocity
   std::vector<double> joint_velocity_cmd_;
-
-  /// \brief vector with the current cmd joint effort
-  std::vector<double> joint_effort_cmd_;
-
-  /// \brief handles to the imus from within Gazebo
-  std::vector<gazebo::sensors::ImuSensorPtr> sim_imu_sensors_;
-
-  /// \brief An array per IMU with 4 orientation, 3 angular velocity and 3 linear acceleration
-  std::vector<std::array<double, 10>> imu_sensor_data_;
-
-  /// \brief handles to the FT sensors from within Gazebo
-  std::vector<gazebo::sensors::ForceTorqueSensorPtr> sim_ft_sensors_;
-
-  /// \brief An array per FT sensor for 3D force and torquee
-  std::vector<std::array<double, 6>> ft_sensor_data_;
 
   /// \brief state interfaces that will be exported to the Resource Manager
   std::vector<hardware_interface::StateInterface> state_interfaces_;
@@ -104,7 +81,6 @@ bool GazeboSystem::initSim(
 
   this->nh_ = model_nh;
   this->dataPtr->parent_model_ = parent_model;
-
   gazebo::physics::PhysicsEnginePtr physics = gazebo::physics::get_world()->Physics();
 
   std::string physics_type_ = physics->GetType();
@@ -114,12 +90,20 @@ bool GazeboSystem::initSim(
   }
 
   registerJoints(hardware_info, parent_model);
-  registerSensors(hardware_info, parent_model);
 
-  if (this->dataPtr->n_dof_ == 0 && this->dataPtr->n_sensors_ == 0) {
+  if (this->dataPtr->n_dof_ == 0) {
     RCLCPP_WARN_STREAM(this->nh_->get_logger(), "There is no joint or sensor available");
     return false;
   }
+
+  joint_controller_ = this->dataPtr->parent_model_->GetJointController();
+  joint_controller_->Reset();
+  steering_joint_ = this->dataPtr->parent_model_->GetJoint(hardware_info.joints[1].name);
+  wheel_front_joint_ = this->dataPtr->parent_model_->GetJoint(hardware_info.joints[2].name);
+  joint_controller_->AddJoint(steering_joint_);
+  joint_controller_->AddJoint(wheel_front_joint_);
+  joint_controller_->SetVelocityPID(steering_joint_->GetScopedName(), gazebo::common::PID(2, 0, 0));
+  joint_controller_->SetPositionPID(wheel_front_joint_->GetScopedName(), gazebo::common::PID(2, 0, 0));
 
   return true;
 }
@@ -134,10 +118,8 @@ void GazeboSystem::registerJoints(
   this->dataPtr->joint_control_methods_.resize(this->dataPtr->n_dof_);
   this->dataPtr->joint_position_.resize(this->dataPtr->n_dof_);
   this->dataPtr->joint_velocity_.resize(this->dataPtr->n_dof_);
-  this->dataPtr->joint_effort_.resize(this->dataPtr->n_dof_);
   this->dataPtr->joint_position_cmd_.resize(this->dataPtr->n_dof_);
   this->dataPtr->joint_velocity_cmd_.resize(this->dataPtr->n_dof_);
-  this->dataPtr->joint_effort_cmd_.resize(this->dataPtr->n_dof_);
 
   for (unsigned int j = 0; j < this->dataPtr->n_dof_; j++) {
     std::string joint_name = this->dataPtr->joint_names_[j] = hardware_info.joints[j].name;
@@ -174,14 +156,6 @@ void GazeboSystem::registerJoints(
           hardware_interface::HW_IF_VELOCITY,
           &this->dataPtr->joint_velocity_cmd_[j]);
       }
-      if (hardware_info.joints[j].command_interfaces[i].name == "effort") {
-        this->dataPtr->joint_control_methods_[j] |= EFFORT;
-        RCLCPP_INFO_STREAM(this->nh_->get_logger(), "\t\t effort");
-        this->dataPtr->command_interfaces_.emplace_back(
-          joint_name,
-          hardware_interface::HW_IF_EFFORT,
-          &this->dataPtr->joint_effort_cmd_[j]);
-      }
     }
 
     RCLCPP_INFO_STREAM(this->nh_->get_logger(), "\tState:");
@@ -202,149 +176,6 @@ void GazeboSystem::registerJoints(
           hardware_interface::HW_IF_VELOCITY,
           &this->dataPtr->joint_velocity_[j]);
       }
-      if (hardware_info.joints[j].state_interfaces[i].name == "effort") {
-        RCLCPP_INFO_STREAM(this->nh_->get_logger(), "\t\t effort");
-        this->dataPtr->state_interfaces_.emplace_back(
-          joint_name,
-          hardware_interface::HW_IF_EFFORT,
-          &this->dataPtr->joint_effort_[j]);
-      }
-    }
-  }
-}
-
-void GazeboSystem::registerSensors(
-  const hardware_interface::HardwareInfo & hardware_info,
-  gazebo::physics::ModelPtr parent_model)
-{
-  // Collect gazebo sensor handles
-  size_t n_sensors = hardware_info.sensors.size();
-  std::vector<hardware_interface::ComponentInfo> imu_components_;
-  std::vector<hardware_interface::ComponentInfo> ft_sensor_components_;
-
-  // This is split in two steps: Count the number and type of sensor and associate the interfaces
-  // So we have resize only once the structures where the data will be stored, and we can safely
-  // use pointers to the structures
-  for (unsigned int j = 0; j < n_sensors; j++) {
-    hardware_interface::ComponentInfo component = hardware_info.sensors[j];
-    std::string sensor_name = component.name;
-
-    // This can't be used, because it only looks for sensor in links, but force_torque_sensor
-    // must be in a joint, as in not found by SensorScopedName
-    // std::vector<std::string> gz_sensor_names = parent_model->SensorScopedName(sensor_name);
-
-    // Workaround to find sensors whose parent is a link or joint of parent_model
-    std::vector<std::string> gz_sensor_names;
-    for (const auto & s : gazebo::sensors::SensorManager::Instance()->GetSensors()) {
-      const std::string sensor_parent = s->ParentName();
-      if (s->Name() != sensor_name) {
-        continue;
-      }
-      if ((parent_model->GetJoint(sensor_parent) != nullptr) ||
-        parent_model->GetLink(sensor_parent) != nullptr)
-      {
-        gz_sensor_names.push_back(s->ScopedName());
-      }
-    }
-    if (gz_sensor_names.empty()) {
-      RCLCPP_WARN_STREAM(
-        this->nh_->get_logger(), "Skipping sensor in the URDF named '" << sensor_name <<
-          "' which is not in the gazebo model.");
-      continue;
-    }
-    if (gz_sensor_names.size() > 1) {
-      RCLCPP_WARN_STREAM(
-        this->nh_->get_logger(), "Sensor in the URDF named '" << sensor_name <<
-          "' has more than one gazebo sensor with the " <<
-          "same name, only using the first. It has " << gz_sensor_names.size() << " sensors");
-    }
-
-    gazebo::sensors::SensorPtr simsensor = gazebo::sensors::SensorManager::Instance()->GetSensor(
-      gz_sensor_names[0]);
-    if (!simsensor) {
-      RCLCPP_ERROR_STREAM(
-        this->nh_->get_logger(),
-        "Error retrieving sensor '" << sensor_name << " from the sensor manager");
-      continue;
-    }
-    if (simsensor->Type() == "imu") {
-      gazebo::sensors::ImuSensorPtr imu_sensor =
-        std::dynamic_pointer_cast<gazebo::sensors::ImuSensor>(simsensor);
-      if (!imu_sensor) {
-        RCLCPP_ERROR_STREAM(
-          this->nh_->get_logger(),
-          "Error retrieving casting sensor '" << sensor_name << " to ImuSensor");
-        continue;
-      }
-      imu_components_.push_back(component);
-      this->dataPtr->sim_imu_sensors_.push_back(imu_sensor);
-    } else if (simsensor->Type() == "force_torque") {
-      gazebo::sensors::ForceTorqueSensorPtr ft_sensor =
-        std::dynamic_pointer_cast<gazebo::sensors::ForceTorqueSensor>(simsensor);
-      if (!ft_sensor) {
-        RCLCPP_ERROR_STREAM(
-          this->nh_->get_logger(),
-          "Error retrieving casting sensor '" << sensor_name << " to ForceTorqueSensor");
-        continue;
-      }
-      ft_sensor_components_.push_back(component);
-      this->dataPtr->sim_ft_sensors_.push_back(ft_sensor);
-    }
-  }
-
-  this->dataPtr->imu_sensor_data_.resize(this->dataPtr->sim_imu_sensors_.size());
-  this->dataPtr->ft_sensor_data_.resize(this->dataPtr->sim_ft_sensors_.size());
-  this->dataPtr->n_sensors_ = this->dataPtr->sim_imu_sensors_.size() +
-    this->dataPtr->sim_ft_sensors_.size();
-
-  for (unsigned int i = 0; i < imu_components_.size(); i++) {
-    const std::string & sensor_name = imu_components_[i].name;
-    RCLCPP_INFO_STREAM(this->nh_->get_logger(), "Loading sensor: " << sensor_name);
-    RCLCPP_INFO_STREAM(
-      this->nh_->get_logger(), "\tState:");
-    for (const auto & state_interface : imu_components_[i].state_interfaces) {
-      static const std::map<std::string, size_t> interface_name_map = {
-        {"orientation.x", 0},
-        {"orientation.y", 1},
-        {"orientation.z", 2},
-        {"orientation.w", 3},
-        {"angular_velocity.x", 4},
-        {"angular_velocity.y", 5},
-        {"angular_velocity.z", 6},
-        {"linear_acceleration.x", 7},
-        {"linear_acceleration.y", 8},
-        {"linear_acceleration.z", 9},
-      };
-      RCLCPP_INFO_STREAM(this->nh_->get_logger(), "\t\t " << state_interface.name);
-
-      size_t data_index = interface_name_map.at(state_interface.name);
-      this->dataPtr->state_interfaces_.emplace_back(
-        sensor_name,
-        state_interface.name,
-        &this->dataPtr->imu_sensor_data_[i][data_index]);
-    }
-  }
-  for (unsigned int i = 0; i < ft_sensor_components_.size(); i++) {
-    const std::string & sensor_name = ft_sensor_components_[i].name;
-    RCLCPP_INFO_STREAM(this->nh_->get_logger(), "Loading sensor: " << sensor_name);
-    RCLCPP_INFO_STREAM(
-      this->nh_->get_logger(), "\tState:");
-    for (const auto & state_interface : ft_sensor_components_[i].state_interfaces) {
-      static const std::map<std::string, size_t> interface_name_map = {
-        {"force.x", 0},
-        {"force.y", 1},
-        {"force.z", 2},
-        {"torque.x", 3},
-        {"torque.y", 4},
-        {"torque.z", 5}
-      };
-      RCLCPP_INFO_STREAM(this->nh_->get_logger(), "\t\t " << state_interface.name);
-
-      size_t data_index = interface_name_map.at(state_interface.name);
-      this->dataPtr->state_interfaces_.emplace_back(
-        sensor_name,
-        state_interface.name,
-        &this->dataPtr->ft_sensor_data_[i][data_index]);
     }
   }
 }
@@ -386,36 +217,9 @@ hardware_interface::return_type GazeboSystem::read()
     if (this->dataPtr->sim_joints_[j]) {
       this->dataPtr->joint_position_[j] = this->dataPtr->sim_joints_[j]->Position(0);
       this->dataPtr->joint_velocity_[j] = this->dataPtr->sim_joints_[j]->GetVelocity(0);
-      this->dataPtr->joint_effort_[j] = this->dataPtr->sim_joints_[j]->GetForce(0u);
     }
   }
 
-  for (unsigned int j = 0; j < this->dataPtr->sim_imu_sensors_.size(); j++) {
-    auto sim_imu = this->dataPtr->sim_imu_sensors_[j];
-    this->dataPtr->imu_sensor_data_[j][0] = sim_imu->Orientation().X();
-    this->dataPtr->imu_sensor_data_[j][1] = sim_imu->Orientation().Y();
-    this->dataPtr->imu_sensor_data_[j][2] = sim_imu->Orientation().Z();
-    this->dataPtr->imu_sensor_data_[j][3] = sim_imu->Orientation().W();
-
-    this->dataPtr->imu_sensor_data_[j][4] = sim_imu->AngularVelocity().X();
-    this->dataPtr->imu_sensor_data_[j][5] = sim_imu->AngularVelocity().Y();
-    this->dataPtr->imu_sensor_data_[j][6] = sim_imu->AngularVelocity().Z();
-
-    this->dataPtr->imu_sensor_data_[j][7] = sim_imu->LinearAcceleration().X();
-    this->dataPtr->imu_sensor_data_[j][8] = sim_imu->LinearAcceleration().Y();
-    this->dataPtr->imu_sensor_data_[j][9] = sim_imu->LinearAcceleration().Z();
-  }
-
-  for (unsigned int j = 0; j < this->dataPtr->sim_ft_sensors_.size(); j++) {
-    auto sim_ft_sensor = this->dataPtr->sim_ft_sensors_[j];
-    this->dataPtr->imu_sensor_data_[j][0] = sim_ft_sensor->Force().X();
-    this->dataPtr->imu_sensor_data_[j][1] = sim_ft_sensor->Force().Y();
-    this->dataPtr->imu_sensor_data_[j][2] = sim_ft_sensor->Force().Z();
-
-    this->dataPtr->imu_sensor_data_[j][3] = sim_ft_sensor->Torque().X();
-    this->dataPtr->imu_sensor_data_[j][4] = sim_ft_sensor->Torque().Y();
-    this->dataPtr->imu_sensor_data_[j][5] = sim_ft_sensor->Torque().Z();
-  }
   return hardware_interface::return_type::OK;
 }
 
@@ -429,23 +233,18 @@ hardware_interface::return_type GazeboSystem::write()
   for (unsigned int j = 0; j < this->dataPtr->joint_names_.size(); j++) {
     if (this->dataPtr->sim_joints_[j]) {
       if (this->dataPtr->joint_control_methods_[j] & POSITION) {
-        this->dataPtr->sim_joints_[j]->SetPosition(
-          0, this->dataPtr->joint_position_cmd_[j],
-          true);
-      }
+        RCLCPP_ERROR(this->nh_->get_logger(), "%s", this->dataPtr->joint_names_[j].c_str());
+        RCLCPP_ERROR(this->nh_->get_logger(), "%f\n",this->dataPtr->joint_position_cmd_[j]);
+        joint_controller_->SetPositionTarget(steering_joint_->GetScopedName(), this->dataPtr->joint_position_cmd_[j]);
+      } 
       if (this->dataPtr->joint_control_methods_[j] & VELOCITY) {
-        this->dataPtr->sim_joints_[j]->SetVelocity(
-          0,
-          this->dataPtr->joint_velocity_cmd_[j]);
-      }
-      if (this->dataPtr->joint_control_methods_[j] & EFFORT) {
-        const double effort =
-          this->dataPtr->joint_effort_cmd_[j];
-        this->dataPtr->sim_joints_[j]->SetForce(0, effort);
+        RCLCPP_ERROR(this->nh_->get_logger(), "%s", this->dataPtr->joint_names_[j].c_str());
+        RCLCPP_ERROR(this->nh_->get_logger(), "%f\n",this->dataPtr->joint_velocity_cmd_[j]);
+        joint_controller_->SetVelocityTarget(wheel_front_joint_->GetScopedName(), this->dataPtr->joint_velocity_cmd_[j]);
       }
     }
   }
-
+  joint_controller_->Update();
   this->dataPtr->last_update_sim_time_ros_ = sim_time_ros;
 
   return hardware_interface::return_type::OK;

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -110,8 +110,8 @@ bool GazeboSystem::initSim(
   double traction_I = std::stod(hardware_info.joints[2].parameters.at("I"));
   double traction_D = std::stod(hardware_info.joints[2].parameters.at("D"));
 
-  joint_controller_->SetVelocityPID(steering_joint_->GetScopedName(), gazebo::common::PID(steering_P, steering_I, steering_D));
-  joint_controller_->SetPositionPID(traction_joint_->GetScopedName(), gazebo::common::PID(traction_P, traction_I, traction_D));
+  joint_controller_->SetPositionPID(steering_joint_->GetScopedName(), gazebo::common::PID(steering_P, steering_I, steering_D));
+  joint_controller_->SetVelocityPID(traction_joint_->GetScopedName(), gazebo::common::PID(traction_P, traction_I, traction_D));
 
   return true;
 }

--- a/gazebo_ros2_control/src/gazebo_system.cpp
+++ b/gazebo_ros2_control/src/gazebo_system.cpp
@@ -109,8 +109,11 @@ bool GazeboSystem::initSim(
   double traction_P = std::stod(hardware_info.joints[2].parameters.at("P"));
   double traction_I = std::stod(hardware_info.joints[2].parameters.at("I"));
   double traction_D = std::stod(hardware_info.joints[2].parameters.at("D"));
-  joint_controller_->SetVelocityPID(steering_joint_->GetScopedName(), gazebo::common::PID(traction_P, traction_I, traction_D));
-  joint_controller_->SetPositionPID(traction_joint_->GetScopedName(), gazebo::common::PID(steering_P, steering_I, steering_D));
+
+        RCLCPP_INFO(this->nh_->get_logger(), "steering_P: %f", steering_P);
+
+  joint_controller_->SetVelocityPID(steering_joint_->GetScopedName(), gazebo::common::PID(steering_P, steering_I, steering_D));
+  joint_controller_->SetPositionPID(traction_joint_->GetScopedName(), gazebo::common::PID(traction_P, traction_I, traction_D));
 
   return true;
 }


### PR DESCRIPTION
Made a minimalist gazebo interface:

- Removed what we are not using
- set a target position/speed to a PID controller instead of direct position/speed

P.S: I tried to put it in amr_gazebo but it's not just the interface we need but also the gazebo plugin so it got complicated. Not impossible but would need more time